### PR TITLE
Add URL validation and --list-formats output (with tests and docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 ## ✨ Features
 
 - **Metadata extraction** - `--info` prints detailed metadata (formats included) as pretty JSON
+- **Format listing** - `--list-formats` prints available formats without downloading
 - **Audio-only downloads** - `--audio` grabs the best audio-only format; otherwise downloads best progressive
 - **Playlist support** - Playlist URLs are expanded and downloaded entry by entry with progress tracking
 - **YouTube Music compatibility** - Automatically converts `music.youtube.com` URLs to regular YouTube URLs
@@ -135,6 +136,11 @@ ytdl-go --info https://www.youtube.com/watch?v=BaW_jenozKc
 
 ![Metadata output example](screenshots/07-metadata-info.svg)
 
+```bash
+# List available formats without downloading
+ytdl-go --list-formats https://www.youtube.com/watch?v=BaW_jenozKc
+```
+
 ### 🎨 Output customization
 
 ```bash
@@ -218,6 +224,7 @@ ytdl-go https://www.youtube.com/watch?v=video1 https://www.youtube.com/watch?v=v
 | `-o` | `{title}.{ext}` | Output path or template with supported placeholders |
 | `-audio` | `false` | Download best available audio-only format |
 | `-info` | `false` | Print video metadata as JSON without downloading |
+| `-list-formats` | `false` | List available formats without downloading |
 | `-quiet` | `false` | Suppress progress output (errors still shown) |
 | `-timeout` | `3m` | Per-request timeout (e.g., 30s, 5m, 1h) |
 

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -15,6 +15,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/kkdai/youtube/v2"
@@ -25,6 +26,7 @@ type Options struct {
 	OutputTemplate string
 	AudioOnly      bool
 	InfoOnly       bool
+	ListFormats    bool
 	Quiet          bool
 	Timeout        time.Duration
 	ProgressLayout string
@@ -75,6 +77,9 @@ func IsReported(err error) bool {
 
 // Process fetches metadata, selects the best matching format, and downloads it.
 func Process(ctx context.Context, url string, opts Options) error {
+	if err := validateURL(url); err != nil {
+		return err
+	}
 	progressManager := newProgressManager(opts)
 	if progressManager != nil {
 		progressManager.Start(ctx)
@@ -93,7 +98,10 @@ func Process(ctx context.Context, url string, opts Options) error {
 	client := newClient(opts)
 	video, err := client.GetVideoContext(ctx, url)
 	if err != nil {
-		return fmt.Errorf("fetching metadata: %w", err)
+		return wrapAccessError(fmt.Errorf("fetching metadata: %w", err))
+	}
+	if opts.ListFormats {
+		return printFormats(video)
 	}
 	if opts.InfoOnly {
 		return printInfo(video)
@@ -124,6 +132,55 @@ func newClient(opts Options) *youtube.Client {
 	}
 }
 
+func validateURL(input string) error {
+	parsed, err := url.Parse(input)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("invalid URL: unsupported scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return errors.New("invalid URL: missing host")
+	}
+	return nil
+}
+
+func wrapAccessError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if isRestrictedAccess(err) {
+		return fmt.Errorf("restricted access: %w", err)
+	}
+	return err
+}
+
+func isRestrictedAccess(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	restrictedMarkers := []string{
+		"private",
+		"sign in",
+		"login",
+		"members only",
+		"premium",
+		"copyright",
+		"unavailable",
+		"age-restricted",
+		"age restricted",
+		"not available",
+	}
+	for _, marker := range restrictedMarkers {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 func processPlaylist(ctx context.Context, url string, opts Options, printer *Printer) error {
 	savedClient := youtube.DefaultClient
 	defer func() {
@@ -134,9 +191,12 @@ func processPlaylist(ctx context.Context, url string, opts Options, printer *Pri
 	playlistClient := newClient(opts)
 	playlist, err := playlistClient.GetPlaylistContext(ctx, url)
 	if err != nil {
-		return fmt.Errorf("fetching playlist: %w", err)
+		return wrapAccessError(fmt.Errorf("fetching playlist: %w", err))
 	}
 
+	if opts.ListFormats {
+		return errors.New("format listing is not supported for playlists")
+	}
 	if opts.InfoOnly {
 		return printPlaylistInfo(playlist)
 	}
@@ -625,6 +685,33 @@ func printInfo(video *youtube.Video) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(payload)
+}
+
+func printFormats(video *youtube.Video) error {
+	return writeFormats(os.Stdout, video)
+}
+
+func writeFormats(output io.Writer, video *youtube.Video) error {
+	writer := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(writer, "itag\tquality\tquality_label\tmime_type\text\tbitrate\tchannels\tresolution\tsize")
+	for _, f := range video.Formats {
+		resolution := ""
+		if f.Width > 0 && f.Height > 0 {
+			resolution = fmt.Sprintf("%dx%d", f.Width, f.Height)
+		}
+		fmt.Fprintf(writer, "%d\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%d\n",
+			f.ItagNo,
+			f.Quality,
+			f.QualityLabel,
+			f.MimeType,
+			mimeToExt(f.MimeType),
+			bitrateForFormat(&f),
+			f.AudioChannels,
+			resolution,
+			f.ContentLength,
+		)
+	}
+	return writer.Flush()
 }
 
 func printPlaylistInfo(playlist *youtube.Playlist) error {

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -1,0 +1,66 @@
+package downloader
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kkdai/youtube/v2"
+)
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "valid https", input: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", wantErr: false},
+		{name: "valid http", input: "http://example.com/video.mp4", wantErr: false},
+		{name: "missing scheme", input: "www.youtube.com/watch?v=dQw4w9WgXcQ", wantErr: true},
+		{name: "missing host", input: "https:///video", wantErr: true},
+		{name: "unsupported scheme", input: "ftp://example.com/video", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateURL(test.input)
+			if test.wantErr && err == nil {
+				t.Fatalf("expected error for %q", test.input)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", test.input, err)
+			}
+		})
+	}
+}
+
+func TestWriteFormats(t *testing.T) {
+	video := &youtube.Video{
+		Formats: []youtube.Format{
+			{
+				ItagNo:        22,
+				Quality:       "hd720",
+				QualityLabel:  "720p",
+				MimeType:      "video/mp4",
+				Bitrate:       2000000,
+				AudioChannels: 2,
+				Width:         1280,
+				Height:        720,
+				ContentLength: 1234,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := writeFormats(&buf, video); err != nil {
+		t.Fatalf("writeFormats returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "itag") {
+		t.Fatalf("expected header in output, got: %q", output)
+	}
+	if !strings.Contains(output, "720p") {
+		t.Fatalf("expected format row in output, got: %q", output)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ func main() {
 	flag.StringVar(&opts.OutputTemplate, "o", "{title}.{ext}", "output path or template (supports {title}, {artist}, {album}, {id}, {ext}, {quality}, {playlist_title}, {playlist_id}, {index}, {count})")
 	flag.BoolVar(&opts.AudioOnly, "audio", false, "download best available audio only")
 	flag.BoolVar(&opts.InfoOnly, "info", false, "print video metadata as JSON without downloading")
+	flag.BoolVar(&opts.ListFormats, "list-formats", false, "list available formats without downloading")
 	flag.DurationVar(&opts.Timeout, "timeout", 3*time.Minute, "per-request timeout")
 	flag.BoolVar(&opts.Quiet, "quiet", false, "suppress progress output (errors still shown)")
 	flag.StringVar(&opts.ProgressLayout, "progress-layout", "", "progress layout template (e.g. \"{label} {percent} {bar} {bytes} {rate} {eta}\")")


### PR DESCRIPTION
### Motivation

- Fail fast on malformed input URLs and surface restricted-access conditions with clearer error text when metadata/playlist fetches fail.
- Allow users to inspect available formats without downloading via a `--list-formats` mode.
- Document the new CLI flag and add unit tests to cover the new behaviors.

### Description

- Add `Options.ListFormats` and a `--list-formats` CLI flag in `main.go` and wire it into `Process` to short-circuit into format listing for single videos via `printFormats`.
- Implement `validateURL` to ensure the input has a supported scheme and host, and call it early in `Process` to reject invalid inputs.
- Add `wrapAccessError` and `isRestrictedAccess` to classify and annotate access-related errors returned from the YouTube client, and apply it when fetching video and playlist metadata.
- Implement `printFormats` and `writeFormats` (using `text/tabwriter`) to render a tabular format list; disallow `--list-formats` for playlists with a clear error.
- Update `README.md` to document the `--list-formats` option and examples, and add `internal/downloader/downloader_test.go` with tests for `validateURL` and `writeFormats`.

### Testing

- Added unit tests in `internal/downloader/downloader_test.go` and attempted to run `go test ./internal/downloader`, however the test run was interrupted while downloading module/toolchain dependencies and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69722ddcd3d08331ad7f1f1873807c1d)