### PR TITLE
Validate input URLs before downloading

### DIFF
--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -82,6 +82,10 @@ func Process(ctx context.Context, url string, opts Options) error {
 	}
 	printer := newPrinter(opts, progressManager)
 
+	if err := validateInputURL(url); err != nil {
+		return err
+	}
+
 	// Convert YouTube Music URLs to regular YouTube URLs
 	url = ConvertMusicURL(url)
 

--- a/internal/downloader/validation.go
+++ b/internal/downloader/validation.go
@@ -1,0 +1,20 @@
+package downloader
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func validateInputURL(raw string) error {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(raw))
+	if err != nil {
+		return fmt.Errorf("invalid url %q: %w", raw, err)
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("invalid url %q: scheme must be http or https", raw)
+	}
+}

--- a/internal/downloader/validation_test.go
+++ b/internal/downloader/validation_test.go
@@ -1,0 +1,29 @@
+package downloader
+
+import "testing"
+
+func TestValidateInputURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "valid http", input: "http://example.com/video.mp4", wantErr: false},
+		{name: "valid https", input: "https://example.com/watch?v=123", wantErr: false},
+		{name: "missing scheme", input: "example.com/video.mp4", wantErr: true},
+		{name: "empty", input: " ", wantErr: true},
+		{name: "unsupported scheme", input: "ftp://example.com/video.mp4", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateInputURL(tc.input)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q", tc.input)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Reject malformed or non-HTTP(S) input URLs early to provide clearer errors and avoid unnecessary work during metadata fetch/download.
- Ensure CLI input validation is explicit and testable before attempting network requests or playlist conversion.

### Description
- Add `validateInputURL` in `internal/downloader/validation.go` to parse and enforce `http`/`https` schemes for input URLs.
- Call `validateInputURL` at the start of `Process` in `internal/downloader/downloader.go` to fail fast on invalid inputs.
- Add unit test `TestValidateInputURL` in `internal/downloader/validation_test.go` covering valid `http`/`https` cases and invalid/missing/unsupported-scheme cases.
- Run `gofmt` on the new files and include the changes in the commit.

### Testing
- Added unit test `TestValidateInputURL` under `internal/downloader` which exercises the new validation helper; the test file was committed. 
- Attempted to run `go test ./...`, but the test run hung in this environment and was terminated, so full test status is unknown. 
- Files were formatted with `gofmt -w` prior to committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972f0df79d08331bd6718b5edd58444)