### PR TITLE
Add concurrent playlist downloads with TUI-based duplicate file prompts

### DIFF
--- a/internal/downloader/adaptive.go
+++ b/internal/downloader/adaptive.go
@@ -91,7 +91,7 @@ func downloadHLS(ctx context.Context, client *youtube.Client, video *youtube.Vid
 	if err != nil {
 		return downloadResult{}, wrapCategory(CategoryFilesystem, err)
 	}
-	outputPath, skip, err := handleExistingPath(outputPath, opts)
+	outputPath, skip, err := handleExistingPath(outputPath, opts, printer)
 	if err != nil {
 		return downloadResult{}, err
 	}

--- a/internal/downloader/dash.go
+++ b/internal/downloader/dash.go
@@ -95,7 +95,7 @@ func downloadDASH(ctx context.Context, client *youtube.Client, video *youtube.Vi
 	if err != nil {
 		return downloadResult{}, wrapCategory(CategoryFilesystem, err)
 	}
-	outputPath, skip, err := handleExistingPath(outputPath, opts)
+	outputPath, skip, err := handleExistingPath(outputPath, opts, printer)
 	if err != nil {
 		return downloadResult{}, err
 	}

--- a/internal/downloader/direct.go
+++ b/internal/downloader/direct.go
@@ -191,7 +191,7 @@ func downloadDirectFile(ctx context.Context, info directInfo, opts Options, prin
 	if err != nil {
 		return downloadResult{}, wrapCategory(CategoryFilesystem, err)
 	}
-	outputPath, skip, err := handleExistingPath(outputPath, opts)
+	outputPath, skip, err := handleExistingPath(outputPath, opts, printer)
 	if err != nil {
 		return downloadResult{}, err
 	}

--- a/internal/downloader/printer.go
+++ b/internal/downloader/printer.go
@@ -363,14 +363,6 @@ func supportsColor() bool {
 	return info.Mode()&os.ModeCharDevice != 0
 }
 
-func supportsANSI() bool {
-	term := os.Getenv("TERM")
-	if term == "dumb" || term == "" {
-		return false
-	}
-	return supportsColor()
-}
-
 const (
 	colorReset  = "\x1b[0m"
 	colorGreen  = "\x1b[32m"


### PR DESCRIPTION
- Add mutex-based prompt synchronization to prevent concurrent user prompts
- Implement parallel playlist processing with configurable worker pool
- Integrate duplicate file prompts into Bubble Tea TUI with spinner and styled options
- Add waitForPromptClear to block downloads during active prompts
- Refactor handleExistingPath to use TUI prompts when progress manager is available
- Fall back to terminal prompts when TUI is disabled