### PR TITLE
Remove unused ProgressRenderer implementation

### DIFF
--- a/internal/downloader/direct.go
+++ b/internal/downloader/direct.go
@@ -124,10 +124,10 @@ func headOrGet(ctx context.Context, rawURL string, timeout time.Duration) (*http
 		return nil, err
 	}
 	resp, err := client.Do(req)
-	if err == nil && resp.StatusCode != http.StatusMethodNotAllowed {
-		return resp, nil
-	}
-	if resp != nil {
+	if err == nil {
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return resp, nil
+		}
 		resp.Body.Close()
 	}
 	req, err = http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)


### PR DESCRIPTION
The ProgressRenderer type and its methods are no longer used after refactoring progress display to use the Printer type directly.