### PR TITLE
Fix ESLint configuration for generated assets

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,9 @@
 module.exports = {
+  ignorePatterns: [
+    'internal/web/assets/app.js',
+    'internal/web/assets/assets/**/*.js',
+    'frontend/node_modules/',
+  ],
   env: {
     browser: true,
     node: true,
@@ -7,7 +12,10 @@ module.exports = {
   extends: ['eslint:recommended'],
   parserOptions: {
     ecmaVersion: 'latest',
-    sourceType: 'module'
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
   },
   rules: {
     'no-undef': 'error',


### PR DESCRIPTION
### Motivation
- Prevent lint failures caused by generated/minified frontend bundles that are checked into `internal/web/assets` and shouldn’t be scanned by ESLint. 
- Allow the shared ESLint config to correctly parse frontend JSX source files so `.jsx` files do not produce parse errors.

### Description
- Update `.eslintrc.js` to add `ignorePatterns` excluding `internal/web/assets/app.js`, `internal/web/assets/assets/**/*.js`, and `frontend/node_modules/` from linting. 
- Enable JSX parsing by setting `parserOptions.ecmaFeatures.jsx` to `true` so ESLint can scan `.jsx` files without parse errors.

### Testing
- Ran `npx eslint@8.10.0 . --config .eslintrc.js --ext .js,.jsx,.ts,.tsx` which completed successfully and now reports only warnings (no lint errors). 
- Generated SARIF output with `npx eslint . --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif` which completed successfully. 
- Performed a frontend production build with `npm run build` in `frontend/` which completed successfully. 
- `go test ./...` timed out in this environment and `npm test` (Vitest) did not complete before being stopped, so those test runs were not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29c250178083319aac3df15b4de881)