### PR TITLE
Potential fix for code scanning alert no. 382: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lvcoi/ytdl-go/security/code-scanning/382](https://github.com/lvcoi/ytdl-go/security/code-scanning/382)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to least privilege.  
Best fix here: define workflow-level permissions directly under `on:` (or under `name:`), before `jobs:`, using:

- `contents: read`

This preserves existing functionality (`actions/checkout` needs repository read) while preventing unintended write scopes from defaults.  
Only `.github/workflows/webpack.yml` needs modification, inserting the block between line 8 and line 9 (before `jobs:`). No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
